### PR TITLE
Influxdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@
 
 # Ignore openai.yml
 /config/openai.yml
+
+# Ignore influxdb.yml
+/config/influxdb.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY . .
 COPY config/database.yml.sample config/database.yml
 COPY config/home_calendar.yml.sample config/home_calendar.yml
 COPY config/openai.yml.sample config/openai.yml
+COPY config/influxdb.yml.sample config/influxdb.yml
 
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'ruby-openai', '~> 7.4'
 # Use Pagy for pagination [https://ddnexus.github.io/pagy/]
 gem 'pagy', '~> 9.3'
 
+# Use influxdb for instrumentation
+gem 'influxdb-client', '~> 3.2'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.2)
     daemons (1.4.1)
     date (3.4.1)
     debug (1.10.0)
@@ -148,6 +149,8 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
+    influxdb-client (3.2.0)
+      csv
     io-console (0.8.0)
     irb (1.15.1)
       pp (>= 0.6.0)
@@ -429,6 +432,7 @@ DEPENDENCIES
   faraday (~> 2.12)
   image_processing (~> 1.2)
   importmap-rails
+  influxdb-client (~> 3.2)
   jbuilder
   mysql2 (~> 0.5)
   pagy (~> 9.3)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ bundle install
 cp config/database.yml.sample config/database.yml
 cp config/home_calendar.yml.sample config/home_calendar.yml
 cp config/openai.yml.smaple config/openai.yml
+cp config/influxdb.yml.sample influxdb.yml
 ```
 
 - Update `config/database.yml` to the the local database credentials
 - Update `config/openai.yml` to the the local ollama instance or disable
 - Optionally update `config/home_calendar.yml` to enable the send to calendar feature
+- Optionally update `config/influxdb.yml` to enable sending traces to InfluxDB
 
 ```
 bin/rails db:create

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,8 @@ module CareerTracker
 
     # Configuration for OpenAI API
     config.openai = config_for(:openai)
+
+    # Configuration for InfluxDB
+    config.influxdb = config_for(:influxdb)
   end
 end

--- a/config/influxdb.yml.sample
+++ b/config/influxdb.yml.sample
@@ -1,0 +1,16 @@
+default: &default
+  enabled: <%= ENV.fetch("INFLUXDB_ENABLED") { false } %>
+  host: <%= ENV.fetch("INFLUXDB_HOST") { 'http://localhost:8086' } %>
+  token: <%= ENV.fetch("INFLUXDB_TOKEN") { 'token' } %>
+  bucket: <%= ENV.fetch("INFLUXDB_BUCKET") { 'career_tracker' } %>
+  org: <%= ENV.fetch("INFLUXDB_ORG") { 'default' } %>
+  use_ssl: <%= ENV.fetch("INFLUXDB_USE_SSL") { true } %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/initializers/influxdb.rb
+++ b/config/initializers/influxdb.rb
@@ -1,3 +1,4 @@
+# :nocov:
 if Rails.application.config.influxdb[:enabled]
   influxdb_client = InfluxDB2::Client.new(
     Rails.application.config.influxdb[:host],
@@ -64,3 +65,4 @@ if Rails.application.config.influxdb[:enabled]
     influxdb_write_api.write(data: hash)
   end
 end
+# :nocov:

--- a/config/initializers/influxdb.rb
+++ b/config/initializers/influxdb.rb
@@ -1,0 +1,66 @@
+if Rails.application.config.influxdb[:enabled]
+  influxdb_client = InfluxDB2::Client.new(
+    Rails.application.config.influxdb[:host],
+    Rails.application.config.influxdb[:token],
+    bucket: Rails.application.config.influxdb[:bucket],
+    org: Rails.application.config.influxdb[:org],
+    precision: InfluxDB2::WritePrecision::NANOSECOND,
+    use_ssl: Rails.application.config.influxdb[:use_ssl]
+  )
+  influxdb_write_api = influxdb_client.create_write_api
+
+  ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |_name, started, finished, _unique_id, data| # rubocop:disable Layout/LineLength
+    hash = {
+      name: 'process_action.action_controller',
+      tags: {
+        method: "#{data[:controller]}##{data[:action]}",
+        format: data[:format],
+        http_method: data[:method],
+        status: data[:status],
+        exception: data[:exception]&.first
+      },
+      fields: {
+        time_in_controller: (finished - started) * 1000,
+        time_in_view: (data[:view_runtime] || 0).ceil,
+        time_in_db: (data[:db_runtime] || 0).ceil
+      },
+      time: started
+    }
+
+    influxdb_write_api.write(data: hash)
+  end
+
+  ActiveSupport::Notifications.subscribe 'render_template.action_view' do |_name, started, finished, _unique_id, data|
+    hash = {
+      name: 'render_template.action_view',
+      tags: {
+        identifier: data[:identifier],
+        layout: data[:layout],
+        exception: data[:exception]&.first
+      },
+      fields: {
+        duration: (finished - started) * 1000
+      },
+      time: started
+    }
+
+    influxdb_write_api.write(data: hash)
+  end
+
+  ActiveSupport::Notifications.subscribe 'sql.active_record' do |_name, started, finished, _unique_id, data|
+    hash = {
+      name: 'sql.active_record',
+      tags: {
+        name: data[:name],
+        statement_name: data[:statement_name],
+        exception: data[:exception]&.first
+      },
+      fields: {
+        duration: (finished - started) * 1000
+      },
+      time: started
+    }
+
+    influxdb_write_api.write(data: hash)
+  end
+end

--- a/spec/system/logout_spec.rb
+++ b/spec/system/logout_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Logout', type: :system do
     click_on 'Sign out'
 
     Capybara.refresh
+    Capybara.refresh
 
     expect(page).to have_content('Sign in')
 


### PR DESCRIPTION
This pull request introduces InfluxDB integration for instrumentation and adds a minor fix to the logout system test. The most important changes include adding necessary configurations and dependencies for InfluxDB, as well as updating relevant documentation.

InfluxDB Integration:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R47): Added a copy command for `config/influxdb.yml.sample` to the Docker image build process.
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR51-R53): Added the `influxdb-client` gem for InfluxDB instrumentation.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R37): Updated setup instructions to include copying and optionally configuring `config/influxdb.yml`.
* [`config/application.rb`](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9R50-R52): Added configuration loading for InfluxDB.
* [`config/influxdb.yml.sample`](diffhunk://#diff-c72cf8013db34ad79c4b88f29bab336062cce025f3c7ec7755e46cf5684c4e5cR1-R16): Added a sample configuration file for InfluxDB.
* [`config/initializers/influxdb.rb`](diffhunk://#diff-b0e66a9e0be2cf0cf07c716a269d0a91fe771a6a735a853e384909fe9b2232feR1-R68): Added an initializer to set up InfluxDB client and subscribe to Rails notifications for capturing metrics.

Minor Fix:

* [`spec/system/logout_spec.rb`](diffhunk://#diff-53bd45535d53398e065102bb7c5246023ab3ae6266503d076f2c5ad8d6917586R18): Added an extra `Capybara.refresh` call to ensure the page is properly refreshed during the logout test.