### PR TITLE
Update Notifications On Next Step Change

### DIFF
--- a/app/controllers/concerns/notification.rb
+++ b/app/controllers/concerns/notification.rb
@@ -4,6 +4,7 @@ module Notification
   included do
     helper_method :next_steps_due_today?
     helper_method :next_steps_past_due?
+    helper_method :find_notifications
   end
 
   class_methods do

--- a/app/controllers/next_steps_controller.rb
+++ b/app/controllers/next_steps_controller.rb
@@ -9,9 +9,7 @@ class NextStepsController < ApplicationController
     @next_step_errors = next_step.errors.full_messages.join(', ') unless next_step.save
     @next_step = NextStep.new(job_application: @job_application)
 
-    respond_to do |format|
-      format.turbo_stream
-    end
+    respond_to_turbo_stream
   end
 
   def update
@@ -21,9 +19,7 @@ class NextStepsController < ApplicationController
       @next_step_errors = @next_step.errors.full_messages.join(', ')
     end
 
-    respond_to do |format|
-      format.turbo_stream
-    end
+    respond_to_turbo_stream
   end
 
   def destroy
@@ -32,9 +28,7 @@ class NextStepsController < ApplicationController
     @job_application = @next_step.job_application
     @next_step.destroy
 
-    respond_to do |format|
-      format.turbo_stream
-    end
+    respond_to_turbo_stream
   end
 
   private
@@ -51,5 +45,13 @@ class NextStepsController < ApplicationController
   def set_next_step
     next_step = NextStep.find_by(id: params[:id])
     @next_step = next_step if next_step&.user == Current.user
+  end
+
+  def respond_to_turbo_stream
+    find_notifications
+
+    respond_to do |format|
+      format.turbo_stream
+    end
   end
 end

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -1,10 +1,12 @@
-<% if next_steps_past_due? %>
-  <div class="text-red-500">
-    <%= t(:past_due_steps) %>: <%= @next_steps_past_due %>
-  </div>
-<% end %>
-<% if next_steps_due_today? %>
-  <div class="text-orange-500">
-    <%= t(:steps_due_today) %>: <%= @next_steps_due_today %>
-  </div>
+<%= turbo_frame_tag 'notification_frame' do %>
+  <% if next_steps_past_due? %>
+    <div class="text-red-500">
+      <%= t(:past_due_steps) %>: <%= @next_steps_past_due %>
+    </div>
+  <% end %>
+  <% if next_steps_due_today? %>
+    <div class="text-orange-500">
+      <%= t(:steps_due_today) %>: <%= @next_steps_due_today %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/next_steps/create.turbo_stream.erb
+++ b/app/views/next_steps/create.turbo_stream.erb
@@ -13,3 +13,7 @@
 <%= turbo_stream.replace 'next_steps_add_dialog_frame',
   partial: 'next_steps/add_dialog'
 %>
+
+<%= turbo_stream.replace 'notification_frame',
+  partial: 'layouts/notifications'
+%>

--- a/app/views/next_steps/destroy.turbo_stream.erb
+++ b/app/views/next_steps/destroy.turbo_stream.erb
@@ -9,3 +9,7 @@
 <%= turbo_stream.replace 'next_steps_error_frame',
   partial: 'next_steps/next_steps_error'
 %>
+
+<%= turbo_stream.replace 'notification_frame',
+  partial: 'layouts/notifications'
+%>

--- a/app/views/next_steps/update.turbo_stream.erb
+++ b/app/views/next_steps/update.turbo_stream.erb
@@ -9,3 +9,7 @@
 <%= turbo_stream.replace 'next_steps_error_frame',
   partial: 'next_steps/next_steps_error'
 %>
+
+<%= turbo_stream.replace 'notification_frame',
+  partial: 'layouts/notifications'
+%>

--- a/spec/system/add_next_step_spec.rb
+++ b/spec/system/add_next_step_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'Add Next Step', type: :system do
 
         expect(page).to have_content('Next steps')
         expect(page).to have_content('Send follow-up email')
+        expect(page).to have_content('Steps due today: 1')
       end.to change(NextStep, :count).by(1)
     end
   end

--- a/spec/system/delete_next_step_spec.rb
+++ b/spec/system/delete_next_step_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe 'Delete Next Step', type: :system do
   it 'deletes a next step' do
     visit job_application_path(next_step.job_application)
 
+    expect(page).to have_content('Past due steps: 1')
+
     click_on "next-step-#{next_step.id}-delete"
 
     expect do
       click_on 'Delete next step'
       expect(page).to have_no_content(next_step.description)
+      expect(page).to have_no_content('Past due steps: 1')
     end.to change(NextStep, :count).by(-1)
   end
 end

--- a/spec/system/update_next_step_spec.rb
+++ b/spec/system/update_next_step_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Update Next Step', type: :system do
     it 'changing the done status of a next step' do
       visit job_application_path(next_step.job_application)
 
+      expect(page).to have_content('Past due steps: 1')
+
       find_by_id("next-step-#{next_step.id}-done").click_on
 
       expect(next_step.reload.done).to be(false)
@@ -38,6 +40,8 @@ RSpec.describe 'Update Next Step', type: :system do
       find_by_id("next-step-#{next_step.id}-done").click_on
 
       expect(next_step.reload.done).to be(true)
+
+      expect(page).to have_no_content('Past due steps: 1')
     end
   end
 end


### PR DESCRIPTION
This pull request introduces several changes aimed at improving the handling and display of notifications related to next steps in the job application process. The changes include updates to the controllers, views, and tests to ensure that notifications are properly displayed and updated in real-time.

Key changes include:

### Controller Updates:
* Added `helper_method :find_notifications` to the `Notification` module in `app/controllers/concerns/notification.rb`.
* Refactored the `create`, `update`, and `destroy` actions in `app/controllers/next_steps_controller.rb` to use a new `respond_to_turbo_stream` method for handling Turbo Stream responses. [[1]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L12-R12) [[2]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L24-R22) [[3]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L35-R31)
* Added the `respond_to_turbo_stream` method to `app/controllers/next_steps_controller.rb`, which includes a call to `find_notifications`.

### View Updates:
* Wrapped notification content in a `turbo_frame_tag` in `app/views/layouts/_notifications.html.erb` to enable Turbo Stream updates. [[1]](diffhunk://#diff-25d9ad940c975c1ec09f4b64750f950ce9d4927467779f5c40d1bcd081478414R1) [[2]](diffhunk://#diff-25d9ad940c975c1ec09f4b64750f950ce9d4927467779f5c40d1bcd081478414R12)
* Added Turbo Stream replacements for the notification frame in the `create`, `update`, and `destroy` Turbo Stream views for next steps. [[1]](diffhunk://#diff-1822e10ddd12a3eacc04dd6d29a6bd1f4424b470117affe432cf716660c07058R16-R19) [[2]](diffhunk://#diff-4b55088fae40779601419b5eac4885e6d741e6e669df391fa2cfdabe8911305bR12-R15) [[3]](diffhunk://#diff-f34072b8deae10fc764c46f142424eb46ab29773cd8942e3f954b5e4074a5785R12-R15)

### Test Updates:
* Updated system tests to verify the presence and absence of notification messages related to next steps. [[1]](diffhunk://#diff-1cabd3ad7bb7516d3312978d745802e99843d6bb21037d5951a98a7d5d78f17cR60) [[2]](diffhunk://#diff-296a9ded7d2252b6d7e0790695857a2de296e685ab77a39205c75e3cabafde83R14-R21) [[3]](diffhunk://#diff-3cee92d737bd3ba9a0ac523ed0af1ac758c813ee0c218dcc0d527840d3e59374R34-R44)