### PR TITLE
Add Job Application Link to Next Steps Table

### DIFF
--- a/app/assets/images/arrow-up-right-square.svg
+++ b/app/assets/images/arrow-up-right-square.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-right-square" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm5.854 8.803a.5.5 0 1 1-.708-.707L9.243 6H6.475a.5.5 0 1 1 0-1h3.975a.5.5 0 0 1 .5.5v3.975a.5.5 0 1 1-1 0V6.707z"/>
+</svg>

--- a/app/views/next_steps/_next_steps_table.html.erb
+++ b/app/views/next_steps/_next_steps_table.html.erb
@@ -15,6 +15,7 @@
           <th class="p-2 border border-gray-300 dark:border-gray-700"><%= t(:description) %></th>
           <th class="p-2 border border-gray-300 dark:border-gray-700"><%= t(:due) %></th>
           <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:edit) %></th>
+          <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:app) %></th>
           <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:delete) %></th>
         </tr>
       </thead>
@@ -42,6 +43,12 @@
             <td class="p-3 border border-gray-300 dark:border-gray-700"><%= next_step.due&.strftime('%Y-%m-%d %H:%M') %></td>
             <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
               <%= render partial: 'next_steps/update_dialog', locals: { next_step: next_step } %>
+            </td>
+            <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
+              <%= link_to image_tag('arrow-up-right-square.svg', alt: t(:app)),
+                          job_application_path(next_step.job_application),
+                          { data: { turbo_frame: '_top' } }
+              %>
             </td>
             <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
               <%= render partial: 'next_steps/delete_dialog', locals: { next_step: next_step } %>

--- a/app/views/next_steps/_next_steps_table.html.erb
+++ b/app/views/next_steps/_next_steps_table.html.erb
@@ -15,7 +15,9 @@
           <th class="p-2 border border-gray-300 dark:border-gray-700"><%= t(:description) %></th>
           <th class="p-2 border border-gray-300 dark:border-gray-700"><%= t(:due) %></th>
           <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:edit) %></th>
-          <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:app) %></th>
+          <% if current_page?(next_steps_path) %>
+            <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:app) %></th>
+          <% end %>
           <th class="p-2 border border-gray-300 dark:border-gray-700 text-left"><%= t(:delete) %></th>
         </tr>
       </thead>
@@ -44,12 +46,14 @@
             <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
               <%= render partial: 'next_steps/update_dialog', locals: { next_step: next_step } %>
             </td>
-            <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
-              <%= link_to image_tag('arrow-up-right-square.svg', alt: t(:app)),
-                          job_application_path(next_step.job_application),
-                          { data: { turbo_frame: '_top' } }
-              %>
-            </td>
+            <% if current_page?(next_steps_path) %>
+              <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
+                <%= link_to image_tag('arrow-up-right-square.svg', alt: t(:app)),
+                            job_application_path(next_step.job_application),
+                            { data: { turbo_frame: '_top' } }
+                %>
+              </td>
+            <% end %>
             <td class="p-3 border border-gray-300 dark:border-gray-700 dark:invert">
               <%= render partial: 'next_steps/delete_dialog', locals: { next_step: next_step } %>
             </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
   ai_file: "AI file"
   all_applications: "All applications"
   answer: "Answer"
+  app: "App"
   applied_on: 'Applied on'
   are_you_sure: "Are you sure?"
   arrow_down: "Arrow down"

--- a/spec/system/add_next_step_spec.rb
+++ b/spec/system/add_next_step_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Add Next Step', type: :system do
         expect(page).to have_content('Next steps')
         expect(page).to have_content('Send follow-up email')
         expect(page).to have_no_content("Description can't be blank")
+        expect(page).to have_no_link('App')
       end.to change(NextStep, :count).by(1)
     end
   end

--- a/spec/system/display_next_steps_spec.rb
+++ b/spec/system/display_next_steps_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe 'Display Next Steps', type: :system do
 
       expect(page).to have_content(next_step.description)
     end
+
+    it 'has link to job application' do
+      next_step
+      visit next_steps_path
+
+      click_on 'App'
+
+      expect(page).to have_content(job_application.position_name)
+    end
   end
 
   context 'when there are no next steps' do


### PR DESCRIPTION
This pull request includes changes to the Next Steps table in the application, adding a new column and functionality to link to job applications. Additionally, it includes updates to localization files and test cases to support the new feature.

Changes to the Next Steps table:

* [`app/views/next_steps/_next_steps_table.html.erb`](diffhunk://#diff-b0af504fc0ea65becb8ca3979c77d1634f4e6d050272a7598d7b86eeea6a63eaR18-R20): Added a new column for the 'App' link that appears only on the Next Steps page. [[1]](diffhunk://#diff-b0af504fc0ea65becb8ca3979c77d1634f4e6d050272a7598d7b86eeea6a63eaR18-R20) [[2]](diffhunk://#diff-b0af504fc0ea65becb8ca3979c77d1634f4e6d050272a7598d7b86eeea6a63eaR49-R56)

Localization updates:

* [`config/locales/en.yml`](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R51): Added the 'App' key for localization.

Test case updates:

* [`spec/system/add_next_step_spec.rb`](diffhunk://#diff-1cabd3ad7bb7516d3312978d745802e99843d6bb21037d5951a98a7d5d78f17cR40): Added a test to ensure the 'App' link does not appear when it should not.
* [`spec/system/display_next_steps_spec.rb`](diffhunk://#diff-f437ac0608df20c29427ea95d33b34f02f63b2a4ad5d838b2d637102ac6c82b7R22-R30): Added a test to verify the presence and functionality of the 'App' link.