### PR TITLE
Paginate Next Steps

### DIFF
--- a/app/controllers/next_steps_controller.rb
+++ b/app/controllers/next_steps_controller.rb
@@ -1,10 +1,11 @@
 class NextStepsController < ApplicationController
   notifications only: %i[index]
+  include Pagy::Backend
   before_action :set_job_application, only: %i[create]
   before_action :set_next_step, only: %i[update destroy]
 
   def index
-    @next_steps = NextStep.ready_next_steps(Current.user)
+    @pagy, @next_steps = pagy(NextStep.ready_next_steps(Current.user))
   end
 
   def create

--- a/app/helpers/next_steps_helper.rb
+++ b/app/helpers/next_steps_helper.rb
@@ -1,0 +1,3 @@
+module NextStepsHelper
+  include Pagy::Frontend
+end

--- a/app/views/next_steps/index.html.erb
+++ b/app/views/next_steps/index.html.erb
@@ -22,5 +22,9 @@
                 next_steps: @next_steps
               }
     %>
+
+    <div class="mt-4">
+      <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+    </div>
   <% end %>
 </div>

--- a/spec/system/display_next_steps_spec.rb
+++ b/spec/system/display_next_steps_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Display Next Steps', type: :system do
       click_on 'Next steps'
 
       expect(page).to have_content(next_step.description)
+      expect(page).to have_no_content('>')
     end
 
     it 'has link to job application' do
@@ -27,6 +28,22 @@ RSpec.describe 'Display Next Steps', type: :system do
       click_on 'App'
 
       expect(page).to have_content(job_application.position_name)
+    end
+
+    it 'paginates next steps' do
+      20.times do |n|
+        create(:next_step, description: "Next Step #{n}", job_application: job_application)
+      end
+
+      visit next_steps_path
+
+      expect(page).to have_content('Next Step 0')
+      expect(page).to have_no_content('Next Step 19')
+
+      click_on '>'
+
+      expect(page).to have_no_content('Next Step 0')
+      expect(page).to have_content('Next Step 19')
     end
   end
 
@@ -39,6 +56,7 @@ RSpec.describe 'Display Next Steps', type: :system do
       visit next_steps_path
 
       expect(page).to have_content('No next steps')
+      expect(page).to have_no_content('>')
 
       click_on 'Home'
     end


### PR DESCRIPTION
This pull request introduces pagination to the `NextStepsController` and updates relevant views and tests to support this new feature. The most important changes include integrating the Pagy gem for pagination, updating the view to display pagination controls, and adding tests to ensure the functionality works as expected.

Pagination Integration:

* [`app/controllers/next_steps_controller.rb`](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3R3-R8): Added the `Pagy::Backend` module and updated the `index` action to use Pagy for paginating `NextStep` records.
* [`app/helpers/next_steps_helper.rb`](diffhunk://#diff-ebc9a3e623449f1e401ce32ff46d353586a7c5f87d25e073cf6865258af482beR1-R3): Included the `Pagy::Frontend` module to support pagination in views.

View Updates:

* [`app/views/next_steps/index.html.erb`](diffhunk://#diff-76be8009b85f8374291c024b40e39cf6139c87b668af19fee8cd88da9fe38c43R25-R28): Added pagination navigation controls to the `index` view to allow users to navigate through paginated `NextStep` records.

Test Enhancements:

* [`spec/system/display_next_steps_spec.rb`](diffhunk://#diff-f437ac0608df20c29427ea95d33b34f02f63b2a4ad5d838b2d637102ac6c82b7R21): Added tests to verify that pagination works correctly, including checking that the pagination controls are present and functional. [[1]](diffhunk://#diff-f437ac0608df20c29427ea95d33b34f02f63b2a4ad5d838b2d637102ac6c82b7R21) [[2]](diffhunk://#diff-f437ac0608df20c29427ea95d33b34f02f63b2a4ad5d838b2d637102ac6c82b7R32-R47) [[3]](diffhunk://#diff-f437ac0608df20c29427ea95d33b34f02f63b2a4ad5d838b2d637102ac6c82b7R59)