### PR TITLE
Add Errors to Next Step Index Page

### DIFF
--- a/app/controllers/next_steps_controller.rb
+++ b/app/controllers/next_steps_controller.rb
@@ -15,7 +15,7 @@ class NextStepsController < ApplicationController
     @next_step_errors = next_step.errors.full_messages.join(', ') unless next_step.save
     @next_step = NextStep.new(job_application: @job_application)
 
-    respond_to_turbo_stream
+    respond_to_format
   end
 
   def update
@@ -25,7 +25,7 @@ class NextStepsController < ApplicationController
       @next_step_errors = @next_step.errors.full_messages.join(', ')
     end
 
-    respond_to_turbo_stream
+    respond_to_format
   end
 
   def destroy
@@ -34,7 +34,7 @@ class NextStepsController < ApplicationController
     @job_application = @next_step.job_application
     @next_step.destroy
 
-    respond_to_turbo_stream
+    respond_to_format
   end
 
   private
@@ -53,12 +53,20 @@ class NextStepsController < ApplicationController
     @next_step = next_step if next_step&.user == Current.user
   end
 
-  def respond_to_turbo_stream
+  def respond_to_format
     find_notifications
 
     respond_to do |format|
-      format.html { redirect_to(next_steps_path) }
+      format.html { html_format }
       format.turbo_stream
+    end
+  end
+
+  def html_format
+    if @next_step_errors.present?
+      redirect_to next_steps_path, alert: @next_step_errors
+    else
+      redirect_to next_steps_path
     end
   end
 end

--- a/app/views/next_steps/index.html.erb
+++ b/app/views/next_steps/index.html.erb
@@ -1,3 +1,5 @@
+<%= render 'layouts/flash' %>
+
 <div class="mt-4">
   <% if @next_steps.empty? %>
     <div class="text-xl dark:text-white mb-4">

--- a/spec/requests/next_steps_controller_spec.rb
+++ b/spec/requests/next_steps_controller_spec.rb
@@ -183,6 +183,22 @@ RSpec.describe NextStepsController, type: :request do
 
         expect(response).to have_http_status(:success)
       end
+
+      it 'renders a alert on html format' do
+        next_step = create(:next_step, job_application: job_application)
+
+        patch next_step_path(next_step), params: invalid_attributes
+
+        expect(flash[:alert]).to eq("Description can't be blank")
+      end
+
+      it 'redirects on html format' do
+        next_step = create(:next_step, job_application: job_application)
+
+        patch next_step_path(next_step), params: invalid_attributes
+
+        expect(response).to redirect_to(next_steps_path)
+      end
     end
   end
 

--- a/spec/system/update_next_step_spec.rb
+++ b/spec/system/update_next_step_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe 'Update Next Step', type: :system do
         visit next_steps_path
 
         click_on "next-step-#{next_step.id}-edit"
+        fill_in('Description', with: '    ')
+        click_on 'Update step'
+
+        expect(page).to have_content("Description can't be blank")
+
+        click_on "next-step-#{next_step.id}-edit"
         fill_in('Description', with: 'Updated step description')
         click_on 'Update step'
 


### PR DESCRIPTION
This pull request includes several changes to the `NextStepsController` and related views and tests to improve error handling and response formats. The most important changes include replacing the `respond_to_turbo_stream` method with a new `respond_to_format` method, updating the view to render flash messages, and adding tests for the new behavior.

Changes to response handling:

* [`app/controllers/next_steps_controller.rb`](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L18-R18): Replaced the `respond_to_turbo_stream` method with `respond_to_format` in the `create`, `update`, and `destroy` actions. Added a new `html_format` method to handle redirection with error messages. [[1]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L18-R18) [[2]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L28-R28) [[3]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L37-R37) [[4]](diffhunk://#diff-0d3846b83c1e9abfefce36a6e53c21cc5738f8e29ca523a01bd3ad013f3a71e3L56-R71)

View updates:

* [`app/views/next_steps/index.html.erb`](diffhunk://#diff-76be8009b85f8374291c024b40e39cf6139c87b668af19fee8cd88da9fe38c43R1-R2): Added a line to render flash messages at the top of the page.

Test updates:

* [`spec/requests/next_steps_controller_spec.rb`](diffhunk://#diff-83ce0b0c8546ec8865fe9036aa1596bd7689822b46cfa7187429c791d56aa56aR186-R201): Added tests to ensure that an alert is rendered and redirection occurs correctly when using the HTML format.
* [`spec/system/update_next_step_spec.rb`](diffhunk://#diff-3cee92d737bd3ba9a0ac523ed0af1ac758c813ee0c218dcc0d527840d3e59374R55-R60): Added a test to check for the presence of an error message when updating a next step with invalid attributes.