### PR TITLE
Add Dark Color Scheme

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="dark:bg-black">
+  <body class="dark:bg-black dark:[color-scheme:dark]">
     <%= render 'layouts/header' %>
     <main class="container px-3 mb-24">
       <%= yield %>


### PR DESCRIPTION
This pull request includes a minor update to the `app/views/layouts/application.html.erb` file to enhance dark mode styling.

Styling improvement:

* Updated the `<body>` tag to include the `dark:[color-scheme:dark]` class, ensuring better compatibility with dark mode by explicitly setting the color scheme. (`[app/views/layouts/application.html.erbL24-R24](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebL24-R24)`)