### PR TITLE
Add Interview Note

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -45,7 +45,7 @@ class InterviewsController < ApplicationController
   private
 
   def interview_params
-    params.expect(interview: %i[interview_start interview_end location job_application_id])
+    params.expect(interview: %i[interview_start interview_end location note job_application_id])
   end
 
   def set_interview

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,10 @@
+import AutoSubmit from "@stimulus-components/auto-submit"
+
+export default class extends AutoSubmit {
+  static values = {
+    delay: {
+      type: Number,
+      default: 1500,
+    },
+  }
+}

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -44,6 +44,22 @@
   %>
 </div>
 
+<%= turbo_frame_tag 'interview_note_turbo_frame' do %>
+  <%= form_with model: @interview, data: { controller: 'auto-submit' } do |form| %>
+    <div class="mt-4 w-full xl:w-2/3 dark:text-white">
+      <%= form.label :note, 'Notes', class: 'text-lg' %>
+        <div class="mt-2">
+          <%= form.textarea :note,
+            rows: 8,
+            class: 'block w-full rounded-md bg-white dark:bg-black px-3 py-1.5 text-base outline-1 -outline-offset-1 outline-gray-300 focus:outline-2 focus:-outline-offset-2 focus:outline-blue-600 sm:text-sm/6',
+            data: { action: 'auto-submit#submit' }
+          %>
+        </div>
+        <%= form.hidden_field :job_application_id, value: @interview.job_application.id %>
+    </div>
+  <% end %>
+<% end %>
+
 <%= render partial: 'next_steps/component', locals: { next_steps: @interview.next_steps_ordered } %>
 
 <% unless @interview.interviewers.blank? %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,4 @@ pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js'
 pin_all_from 'app/javascript/controllers', under: 'controllers'
 pin 'trix'
 pin '@rails/actiontext', to: 'actiontext.esm.js'
+pin '@stimulus-components/auto-submit', to: '@stimulus-components--auto-submit.js' # @6.0.0

--- a/db/migrate/20250510174659_add_note_to_interview.rb
+++ b/db/migrate/20250510174659_add_note_to_interview.rb
@@ -1,0 +1,5 @@
+class AddNoteToInterview < ActiveRecord::Migration[8.0]
+  def change
+    add_column :interviews, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_05_162350) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_10_174659) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -107,6 +107,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_05_162350) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "home_calendar_event_id"
+    t.text "note"
     t.index ["job_application_id"], name: "index_interviews_on_job_application_id"
   end
 

--- a/spec/system/update_interview_spec.rb
+++ b/spec/system/update_interview_spec.rb
@@ -36,4 +36,16 @@ RSpec.describe 'Update Interview', type: :system do
 
     expect(page).to have_content("Location can't be blank")
   end
+
+  it 'Updates the notes field' do
+    visit interview_path(interview)
+
+    fill_in 'Notes', with: 'Notes during the interview'
+
+    sleep(2.5) # Wait for autosave to complete
+    interview.reload
+
+    expect(interview.note).to eq('Notes during the interview')
+    expect(page).to have_content('Notes during the interview')
+  end
 end

--- a/vendor/javascript/@stimulus-components--auto-submit.js
+++ b/vendor/javascript/@stimulus-components--auto-submit.js
@@ -1,0 +1,4 @@
+// @stimulus-components/auto-submit@6.0.0 downloaded from https://ga.jspm.io/npm:@stimulus-components/auto-submit@6.0.0/dist/stimulus-auto-submit.mjs
+
+import{Controller as t}from"@hotwired/stimulus";function debounce(t,e){let i;return(...s)=>{clearTimeout(i),i=setTimeout((()=>{t.apply(this,s)}),e)}}const e=class _AutoSubmit extends t{initialize(){this.submit=this.submit.bind(this)}connect(){this.delayValue>0&&(this.submit=debounce(this.submit,this.delayValue))}submit(){this.element.requestSubmit()}};e.values={delay:{type:Number,default:150}};let i=e;export{i as default};
+


### PR DESCRIPTION
This pull request introduces a "Notes" feature for interviews, allowing users to add and auto-save notes during the interview process. It also integrates a Stimulus component for auto-submission functionality. Below are the most important changes:

### Backend Changes:
* Updated `interview_params` in `app/controllers/interviews_controller.rb` to permit the new `note` field.
* Added a migration (`db/migrate/20250510174659_add_note_to_interview.rb`) to include a `note` column of type `text` in the `interviews` table.
* Updated `db/schema.rb` to reflect the new `note` column in the `interviews` table. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R110)

### Frontend Changes:
* Added a notes section to `app/views/interviews/show.html.erb`, including a textarea for the `note` field with auto-submit functionality.
* Introduced a new Stimulus controller (`app/javascript/controllers/auto_submit_controller.js`) to handle auto-submission of the notes field with a default delay of 1500ms.
* Updated `config/importmap.rb` to pin the `@stimulus-components/auto-submit` package for use in the application.

### Testing:
* Added a system test (`spec/system/update_interview_spec.rb`) to verify that the "Notes" field updates correctly and is auto-saved.