### PR TITLE
Do Not Clear Site Data on Logout

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -50,8 +50,4 @@ module Authentication
     Current.session.destroy
     cookies.delete(:session_id)
   end
-
-  def clear_site_data
-    response.headers['Clear-Site-Data'] = '"cache","storage"'
-  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,6 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
-    clear_site_data
     redirect_to new_session_path
   end
 end

--- a/spec/system/logout_spec.rb
+++ b/spec/system/logout_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Logout', type: :system do
 
     click_on 'Sign in'
 
+    expect(page).to have_content('Career Tracker')
     expect(page).to have_content('Sign out')
 
     click_on 'Sign out'

--- a/spec/system/logout_spec.rb
+++ b/spec/system/logout_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe 'Logout', type: :system do
 
     click_on 'Sign out'
 
-    Capybara.refresh
-    Capybara.refresh
-
     expect(page).to have_content('Sign in')
 
     visit root_path


### PR DESCRIPTION
This pull request simplifies the logout process by removing redundant code and unnecessary steps. The main changes involve cleaning up the session termination logic and streamlining the logout system test.

Clearing the site data causes Chrome to clear for 30 seconds.

Session termination logic:

* Removed the `clear_site_data` method from `app/controllers/concerns/authentication.rb` and its invocation in the `destroy` action of `SessionsController`, eliminating the setting of the `Clear-Site-Data` header during logout. [[1]](diffhunk://#diff-8fb386345eced6ce59dafa10d303ccbf4acc6a6d4ad828d08758a0a7ff4f57e6L53-L56) [[2]](diffhunk://#diff-cdec550eeeb8fc63be2b5687170f594651a8d0b7f0465c9d807baef392639b6eL20)

System test cleanup:

* Removed duplicate `Capybara.refresh` calls from the logout system test in `spec/system/logout_spec.rb`, making the test more efficient.