### PR TITLE
Add libyaml-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git pkg-config && \
+    apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git pkg-config libyaml-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
This pull request makes a minor update to the Docker build environment by adding a missing package required for building gems.

- Dockerfile improvements:
  * Added `libyaml-dev` to the list of packages installed during the build stage to ensure compatibility with gems that depend on YAML support.